### PR TITLE
Fixed the env.HUBOT_IMGUR_CLIENTID check

### DIFF
--- a/src/reaction-gifs.coffee
+++ b/src/reaction-gifs.coffee
@@ -33,7 +33,7 @@
 #   mbesto
 
 token = "Client-ID #{process.env.HUBOT_IMGUR_CLIENTID}"
-unless token
+unless process.env.HUBOT_IMGUR_CLIENTID
   throw "You must set HUBOT_IMGUR_CLIENTID in your environment vairables"
 
 api_url = "https://api.imgur.com/3/album/"


### PR DESCRIPTION
because token is set to "Client-ID" and the env.HUBOT_IMGUR_CLIENTID, it will always be at least "Client-ID" so the unless check will never fail.